### PR TITLE
fix: update code to use variable

### DIFF
--- a/vcf-import-lab-deployment.ps1
+++ b/vcf-import-lab-deployment.ps1
@@ -698,7 +698,7 @@ if($finalCleanUp -eq 1) {
 
 if($uploadVCFImportTool -eq 1) {
     My-Logger "Connecting to new vCenter Server $VCSADisplayName ..."
-    $viConnection = Connect-VIServer $VCSAIPAddress -User "administrator@vsphere.local" -Password $VCSASSOPassword -WarningAction SilentlyContinue
+    $viConnection = Connect-VIServer $VCSAIPAddress -User "administrator@$VCSASSODomainName" -Password $VCSASSOPassword -WarningAction SilentlyContinue
 
     $VCFImportToolFile = Split-Path $VCFImportToolpath -Leaf
 


### PR DESCRIPTION
line 701 is hardcoded to use `administrator@vsphere.local`.  this will cause an error connecting to the vcenter if the `$VCSASSODomainName` variable is ever changed from the default. this fix changes the code to use `administrator@$VCSASSODomainName` instead as is done in various parts of the script.